### PR TITLE
Terraform to provision Linstor vms

### DIFF
--- a/terraform/incus/main.tf
+++ b/terraform/incus/main.tf
@@ -1,0 +1,85 @@
+resource "incus_network" "this" {
+  name = "dev-net"
+
+  config = {
+    "ipv4.address" = var.network_ipv4_cidr
+    "ipv4.nat"     = "true"
+    "ipv6.address" = var.network_ipv6_cidr
+    "ipv6.nat"     = "true"
+  }
+}
+
+resource "incus_storage_pool" "this" {
+  name   = "linstor-pool"
+  driver = "lvm"
+}
+
+resource "incus_storage_volume" "this" {
+  name         = "vol1"
+  pool         = incus_storage_pool.this.name
+  content_type = "block"
+  config = {
+    "size" = var.volume_size
+  }
+}
+
+resource "incus_profile" "this" {
+  name = "profile1"
+
+  config = {
+    "limits.cpu" = var.cpu_count
+  }
+
+  device {
+    name = "disk"
+    type = "disk"
+
+    properties = {
+      pool = incus_storage_pool.this.name
+      path = "/"
+    }
+  }
+
+  device {
+    name = "eth1"
+    type = "nic"
+
+    properties = {
+      "network" = incus_network.this.name
+      "name"    = "eth1"
+    }
+
+  }
+}
+
+resource "incus_instance" "this" {
+  count    = var.instance_count
+  name     = "${var.instance_name}${var.instance_count > 1 ? "-${count.index + 1}" : ""}"
+  image    = var.image
+  type     = "virtual-machine"
+  profiles = [incus_profile.this.name]
+
+  config = {
+    "limits.cpu"    = var.cpu_count
+    "limits.memory" = var.memory_count
+  }
+
+  #NOTE(wncslln): improve this block to accept more disks as input
+  dynamic "device" {
+    for_each = [1]
+
+    content {
+      type = "disk"
+      name = "disk1"
+
+      properties = {
+        pool   = incus_storage_pool.this.name
+        source = incus_storage_volume.this.name
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [running]
+  }
+}

--- a/terraform/incus/variables.tf
+++ b/terraform/incus/variables.tf
@@ -1,0 +1,38 @@
+# Add description for each variable
+variable "instance_name" {
+  type    = string
+  default = ""
+}
+
+variable "instance_count" {
+  type    = number
+  default = 1
+}
+
+variable "cpu_count" {
+  type    = string
+  default = "1"
+}
+
+variable "memory_count" {
+  type    = string
+  default = "1GiB"
+}
+
+variable "image" {
+  type    = string
+  default = "images:ubuntu/22.04"
+}
+
+variable "network_ipv4_cidr" {
+  type = string
+}
+
+variable "network_ipv6_cidr" {
+  type = string
+}
+
+variable "volume_size" {
+  type    = string
+  default = "5GiB"
+}

--- a/terraform/incus/versions.tf
+++ b/terraform/incus/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">=1.5.7"
+  required_providers {
+    incus = {
+      source  = "lxc/incus"
+      version = ">=0.1.2"
+    }
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,9 @@
+module "instance" {
+  source = "./incus"
+
+  instance_name     = "linstor"
+  network_ipv4_cidr = "192.0.2.1/24"
+  network_ipv6_cidr = "2002::1234:abcd:ffff:c0a8:101/64"
+
+  volume_size = "2GiB"
+}

--- a/terraform/provider_incus.tf
+++ b/terraform/provider_incus.tf
@@ -1,0 +1,7 @@
+provider "incus" {
+  remote {
+    name    = var.incus_remote
+    default = true
+  }
+}
+

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,1 @@
+incus_remote = "local"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,4 @@
+variable "incus_remote" {
+  type    = string
+  default = "local"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">=1.5.7"
+  required_providers {
+    incus = {
+      source  = "lxc/incus"
+      version = ">=0.1.2"
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces the terraform automation to provision virtual machines to get a Linstor deploy.

Currently, only one bridged network and one storage volume are created, but we may support more volumes since we're working with an SDS.

Also, the automation uses the local remote, so if we intend to use this with a remote server, we should change the `provider_incus.tf` to accept it.